### PR TITLE
automatic release created for v1.0.0-beta.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.0-beta.29] - 2019-03-26
+
+[Added] [\#2238](https://github.com/cosmos/voyager/issues/2238) Show estimaded fees @fedekunze
+[Changed] Circleci config deployment job to deploy `lunie.io` and `beta.lunie.io`
+[Changed] renamed to Lunie @faboweb
+
 ## [1.0.0-beta.28] - 2019-03-25
 
 ### Added

--- a/PENDING.md
+++ b/PENDING.md
@@ -1,3 +1,0 @@
-[Added] [\#2238](https://github.com/cosmos/voyager/issues/2238) Show estimaded fees @fedekunze
-[Changed] Circleci config deployment job to deploy `lunie.io` and `beta.lunie.io`
-[Changed] renamed to Lunie @faboweb

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lunie",
   "productName": "lunie",
-  "version": "1.0.0-beta.28",
+  "version": "1.0.0-beta.29",
   "description": "Lunie is a web based user interface for the Cosmos Hub.",
   "author": "All In Bits, Inc <hello@tendermint.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
[Added] [\#2238](https://github.com/cosmos/voyager/issues/2238) Show estimaded fees @fedekunze
[Changed] Circleci config deployment job to deploy `lunie.io` and `beta.lunie.io`
[Changed] renamed to Lunie @faboweb
