### PR TITLE
automatic release created for v1.0.0-beta.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.0-beta.29] - 2019-03-27
+
+[Changed] [\#2337](https://github.com/cosmos/voyager/pull/2337) Show rewards in header on mobile @faboweb
+[Changed] [\#2361](https://github.com/cosmos/lunie/pull/2361) Complete renaming of README to Lunie @sabau
+[Fixed] [\#2358](https://github.com/cosmos/lunie/pull/2358) Fixed store cache retrieval on sign in @faboweb
+[Fixed] [\#2250](https://github.com/cosmos/lunie/issues/2250) Fixed staking transactions invalid date @fedekunze
+
+
 ## [1.0.0-beta.28] - 2019-03-25
 
 ### Added

--- a/PENDING.md
+++ b/PENDING.md
@@ -1,2 +1,3 @@
+[Changed] [\#2337](https://github.com/cosmos/voyager/pull/2337) Show rewards in header on mobile @faboweb
 [Changed] [\#2361](https://github.com/cosmos/lunie/pull/2361) Complete renaming of README to Lunie @sabau
 [Fixed] [\#2358](https://github.com/cosmos/lunie/pull/2358) Fixed store cache retrieval on sign in @faboweb

--- a/PENDING.md
+++ b/PENDING.md
@@ -1,3 +1,4 @@
 [Changed] [\#2337](https://github.com/cosmos/voyager/pull/2337) Show rewards in header on mobile @faboweb
 [Changed] [\#2361](https://github.com/cosmos/lunie/pull/2361) Complete renaming of README to Lunie @sabau
 [Fixed] [\#2358](https://github.com/cosmos/lunie/pull/2358) Fixed store cache retrieval on sign in @faboweb
+[Fixed] [\#2250](https://github.com/cosmos/lunie/issues/2250) Fixed staking transactions invalid date @fedekunze

--- a/PENDING.md
+++ b/PENDING.md
@@ -1,1 +1,2 @@
 [Changed] [\#2361](https://github.com/cosmos/lunie/pull/2361) Complete renaming of README to Lunie @sabau
+[Fixed] [\#2358](https://github.com/cosmos/lunie/pull/2358) Fixed store cache retrieval on sign in @faboweb

--- a/PENDING.md
+++ b/PENDING.md
@@ -1,4 +1,0 @@
-[Changed] [\#2337](https://github.com/cosmos/voyager/pull/2337) Show rewards in header on mobile @faboweb
-[Changed] [\#2361](https://github.com/cosmos/lunie/pull/2361) Complete renaming of README to Lunie @sabau
-[Fixed] [\#2358](https://github.com/cosmos/lunie/pull/2358) Fixed store cache retrieval on sign in @faboweb
-[Fixed] [\#2250](https://github.com/cosmos/lunie/issues/2250) Fixed staking transactions invalid date @fedekunze

--- a/PENDING.md
+++ b/PENDING.md
@@ -1,3 +1,1 @@
-[Added] [\#2238](https://github.com/cosmos/voyager/issues/2238) Show estimaded fees @fedekunze
-[Changed] Circleci config deployment job to deploy `lunie.io` and `beta.lunie.io`
-[Changed] renamed to Lunie @faboweb
+[Changed] [\#2361](https://github.com/cosmos/lunie/pull/2361) Complete renaming of README to Lunie @sabau

--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 # Cosmos Lunie
 
-[![CircleCI](https://circleci.com/gh/cosmos/voyager.svg?style=svg)](https://circleci.com/gh/cosmos/voyager)
-[![codecov](https://codecov.io/gh/cosmos/voyager/branch/develop/graph/badge.svg)](https://codecov.io/gh/cosmos/voyager)
+[![CircleCI](https://circleci.com/gh/cosmos/lunie.svg?style=svg)](https://circleci.com/gh/cosmos/lunie)
+[![codecov](https://codecov.io/gh/cosmos/lunie/branch/develop/graph/badge.svg)](https://codecov.io/gh/cosmos/lunie)
 
 👋 Welcome to Lunie, the official wallet and UI for the [Cosmos Hub](https://cosmos.network/).
 
 ⚠️ This is still alpha-level software. **DO NOT** enter your Cosmos fundraiser seed into Lunie.
 
-<!-- 🎉 Binary releases are [available here](https://github.com/cosmos/voyager/releases). After downloading and untar/unzip-ing, navigate to the source directory and click on the `Cosmos Voyager` icon to launch Voyager. -->
+<!-- 🎉 Binary releases are [available here](https://github.com/cosmos/lunie/releases). After downloading and untar/unzip-ing, navigate to the source directory and click on the `Cosmos Lunie` icon to launch Lunie. -->
 
 ## Lunie Dependencies
 
-Install the following dependencies if you wish to run voyager on developer mode or [contribute](https://github.com/cosmos/voyager/blob/develop/CONTRIBUTING.md).
+Install the following dependencies if you wish to run lunie on developer mode or [contribute](https://github.com/cosmos/lunie/blob/develop/CONTRIBUTING.md).
 
 ### Node
 
@@ -47,8 +47,8 @@ Lunie supports sending transactions through the `Cøsmos` app for [Ledger Nano S
 With Node, Yarn and Docker installed, you're ready to check out the source code:
 
 ```bash
-git clone https://github.com/cosmos/voyager.git
-cd voyager
+git clone https://github.com/cosmos/lunie.git
+cd lunie
 yarn install
 ```
 

--- a/app/src/renderer/components/common/TmBalance.vue
+++ b/app/src/renderer/components/common/TmBalance.vue
@@ -161,17 +161,16 @@ export default {
     padding: 0 0 1.5rem 0;
   }
 
-  .header-balance .top {
-    flex-direction: column;
-  }
-
   .top-section {
     padding: 0.5rem 0 1rem;
     border-right: none;
   }
 
-  .top-section:nth-child(2),
-  .top-section:nth-child(3) {
+  .top-section:not(:first-child) {
+    margin-left: 2rem;
+  }
+
+  .top-section:nth-child(2) {
     display: none;
   }
 }

--- a/app/src/renderer/components/staking/TabMyDelegations.vue
+++ b/app/src/renderer/components/staking/TabMyDelegations.vue
@@ -143,8 +143,7 @@ export default {
   methods: {
     async loadStakingTxs() {
       if (this.session.signedIn) {
-        const stakingTxs = await this.$store.dispatch(`getTx`, `staking`)
-        this.$store.commit(`setStakingTxs`, stakingTxs)
+        await this.$store.dispatch(`getAllTxs`)
       }
     }
   }

--- a/app/src/renderer/components/transactions/LiStakeTransaction.vue
+++ b/app/src/renderer/components/transactions/LiStakeTransaction.vue
@@ -211,7 +211,7 @@ export default {
     },
     time: {
       type: String,
-      default: null // TODO: fails with required: true
+      required: true
     },
     block: {
       type: Number,

--- a/app/src/renderer/components/transactions/LiTransaction.vue
+++ b/app/src/renderer/components/transactions/LiTransaction.vue
@@ -22,7 +22,7 @@
         <div class="li-tx__content__block">
           <router-link :to="{ name: `block`, params: { height: block } }">
             Block #{{ block }}&nbsp;
-          </router-link>{{ date !== `Invalid date` ? `@ ${date}` : `` }}
+          </router-link>@&nbsp;{{ date }}
         </div>
       </div>
     </div>
@@ -41,7 +41,7 @@ export default {
     },
     time: {
       type: String,
-      default: null // TODO: fails with required: true
+      required: true
     },
     block: {
       type: Number,

--- a/app/src/renderer/vuex/getters.js
+++ b/app/src/renderer/vuex/getters.js
@@ -15,11 +15,12 @@ export const lastPage = state => {
 // wallet
 export const transactions = state => state.transactions
 export const allTransactions = state =>
-  state.transactions.bank.concat(
-    state.transactions.staking,
-    state.transactions.governance,
-    state.transactions.distribution
-  )
+  state.transactions.bank
+    .concat(
+      state.transactions.staking,
+      state.transactions.governance,
+      state.transactions.distribution
+    )
 export const ledger = state => state.ledger
 export const wallet = state => state.wallet
 

--- a/app/src/renderer/vuex/store.js
+++ b/app/src/renderer/vuex/store.js
@@ -91,7 +91,6 @@ function persistState(state) {
       balances: state.wallet.balances
     },
     delegation: {
-      loaded: state.delegation.loaded,
       committedDelegates: state.delegation.committedDelegates,
       unbondingDelegations: state.delegation.unbondingDelegations
     },
@@ -128,7 +127,12 @@ export function getStorageKey(state) {
  * @param state
  * @param commit
  */
-export function loadPersistedState({ state, commit }) {
+export async function loadPersistedState({ state, commit, dispatch }) {
+  if (!state.connection.lastHeader || !state.connection.lastHeader.chain_id) {
+    await new Promise(resolve => setTimeout(resolve, 500))
+    dispatch(`loadPersistedState`)
+    return
+  }
   const storageKey = getStorageKey(state)
   let cachedState
   try {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lunie",
   "productName": "lunie",
-  "version": "1.0.0-beta.28",
+  "version": "1.0.0-beta.29",
   "description": "Lunie is a web based user interface for the Cosmos Hub.",
   "author": "All In Bits, Inc <hello@tendermint.com>",
   "license": "Apache-2.0",

--- a/test/unit/specs/components/transactions/__snapshots__/LiTransaction.spec.js.snap
+++ b/test/unit/specs/components/transactions/__snapshots__/LiTransaction.spec.js.snap
@@ -54,7 +54,7 @@ exports[`LiTransaction should show a transaction item 1`] = `
           Block #500 
         
         </router-link-stub>
-        @ 00:00:42
+        @ 00:00:42
       
       </div>
     </div>


### PR DESCRIPTION
[Changed] [\#2337](https://github.com/cosmos/voyager/pull/2337) Show rewards in header on mobile @faboweb
[Changed] [\#2361](https://github.com/cosmos/lunie/pull/2361) Complete renaming of README to Lunie @sabau
[Fixed] [\#2358](https://github.com/cosmos/lunie/pull/2358) Fixed store cache retrieval on sign in @faboweb
[Fixed] [\#2250](https://github.com/cosmos/lunie/issues/2250) Fixed staking transactions invalid date @fedekunze

